### PR TITLE
Fix the issue on self-hosting Timeplus

### DIFF
--- a/apps/cli/src/commands/start/timeplus.ts
+++ b/apps/cli/src/commands/start/timeplus.ts
@@ -4,7 +4,7 @@ import { TimeplusDestination } from '../../destinations/timeplus/timeplus.js'
 import { Destination } from '../../destinations/base.js'
 
 export default class StartTimeplus extends BaseStartCommand<typeof StartTimeplus> {
-  static description = 'Start the timeplus feed'
+  static description = 'Start the Timeplus feed'
 
   static examples = [
     '<%= config.bin %> <%= command.id %> timeplus --stream bluebird_feed --token XXX --endpoint https://us-west-2.timeplus.cloud/myworkspace',

--- a/apps/cli/src/destinations/timeplus/timeplus.ts
+++ b/apps/cli/src/destinations/timeplus/timeplus.ts
@@ -24,21 +24,28 @@ export class TimeplusDestination extends Destination {
     super();
     this.config = config;
   }
+  
+  getAuthHeaderValue(): string {
+    let auth: string = `ApiKey ${this.config.token}`;
+    if (this.config.token.length !== 60) {
+      auth = `Basic ${Buffer.from(this.config.token).toString('base64')}`;
+    }
+
+    return auth;
+  }
 
   async init(): Promise<void> {
     // validate the 3 inputs and create the stream if not exists
     const url = `${this.config.endpoint}/api/v1beta2/streams/${this.config.stream}`;
-    let auth: string = `ApiKey ${this.config.token}`;
 
     if (this.config.token.length === 60) {
       console.log(`Validating API token for ${this.config.endpoint}`);
     } else {
       console.log('This is not an API token. Assuming it is admin:password, encoding it as base64 and validating');
-      auth = `Basic ${Buffer.from(this.config.token).toString('base64')}`;
     }
 
     const headers: HeadersInit = {
-      Authorization: auth,
+      Authorization: this.getAuthHeaderValue(),
       'Content-Type': 'application/json',
     };
 
@@ -95,7 +102,7 @@ export class TimeplusDestination extends Destination {
     const response = await fetch(url, {
       method: 'POST',
       headers: {
-        Authorization: `ApiKey ${this.config.token}`,
+        Authorization: this.getAuthHeaderValue(),
         'Content-Type': 'application/json',
       },
       body: jsonl,


### PR DESCRIPTION
Sorry I realized there was an issue to run this CLI on self-hosting Timeplus Enterprise. The http header need to be set properly to transform the token.

To test it, maybe you can run the Timeplus Enterprise via a docker 
```bash
docker run --name tpe2.5.11 -p 8000:8000 timeplus/timeplus-enterprise:2.5.11
```
Then access http://localhost:8000 and create the user with name `admin` and password `changeme`

Then you can run the CLI via
```
./bin/dev.js start timeplus --token admin:changeme --endpoint http://localhost:8000/local --stream jovetmpd12
```